### PR TITLE
Add features dataset to examples

### DIFF
--- a/example_instruments/loki/LOKI_example.py
+++ b/example_instruments/loki/LOKI_example.py
@@ -3,15 +3,14 @@ from detectorplotter import DetectorPlotter
 
 if __name__ == '__main__':
     output_filename = 'LOKI_example_gzip.hdf5'
-    builder = NexusBuilder(output_filename, idf_file='LOKI_Definition.xml',
-                           compress_type='gzip', compress_opts=1)
+    with NexusBuilder(output_filename, idf_file='LOKI_Definition.xml',
+                      compress_type='gzip', compress_opts=1) as builder:
+        builder.add_instrument_geometry_from_idf()
 
-    builder.add_instrument_geometry_from_idf()
-
-    # A few more details to flesh out the example
-    builder.add_user('LOKI Team', 'ESS')
-    builder.add_dataset('/raw_data_1/', 'definition', 'TOFRAW',
-                        {'url': 'http://definition.nexusformat.org/instruments/TOFRAW?version=1.0'})
+        # A few more details to flesh out the example
+        builder.add_user('LOKI Team', 'ESS')
+        builder.add_dataset('/raw_data_1/', 'definition', 'TOFRAW',
+                            {'url': 'http://definition.nexusformat.org/instruments/TOFRAW?version=1.0'})
 
     plotter = DetectorPlotter(output_filename)
     plotter.plot_pixel_positions()

--- a/example_instruments/sans2d/SANS2D_example.py
+++ b/example_instruments/sans2d/SANS2D_example.py
@@ -5,55 +5,53 @@ from detectorplotter import DetectorPlotter
 if __name__ == '__main__':
     output_filename = 'SANS_example_gzip_compress.hdf5'
     # compress_type=32001 for BLOSC, or don't specify compress_type and opts to get non-compressed datasets
-    builder = NexusBuilder(output_filename, input_nexus_filename='SANS_test.nxs',
-                           idf_file='SANS2D_Definition_Tubes.xml', compress_type='gzip', compress_opts=1)
+    with NexusBuilder(output_filename, input_nexus_filename='SANS_test.nxs',
+                      idf_file='SANS2D_Definition_Tubes.xml', compress_type='gzip', compress_opts=1) as builder:
+        builder.add_instrument_geometry_from_idf()
 
-    builder.add_instrument_geometry_from_idf()
+        # Define monitor_1 to have the shape of the Utah teapot as example use of NXshape
+        builder.add_shape_from_file('teapot.off', 'instrument/monitor1', 'shape')
 
-    # Define monitor_1 to have the shape of the Utah teapot as example use of NXshape
-    builder.add_shape_from_file('teapot.off', 'instrument/monitor1', 'shape')
-
-    # Copy data from the existing NeXus file to flesh out the example file
-    builder.add_user('Sans2d Team', 'ISIS, STFC')
-    builder.copy_items(OrderedDict([('raw_data_1/instrument/moderator', 'raw_data_1/instrument/moderator'),
-                                    ('raw_data_1/instrument/moderator/distance',
-                                     'raw_data_1/instrument/moderator/distance'),
-                                    ('raw_data_1/instrument/source/probe', 'raw_data_1/instrument/source/probe'),
-                                    ('raw_data_1/instrument/source/type', 'raw_data_1/instrument/source/type'),
-                                    ('raw_data_1/sample/name', 'raw_data_1/sample/name'),
-                                    ('raw_data_1/sample/type', 'raw_data_1/sample/type'),
-                                    ('raw_data_1/good_frames', 'raw_data_1/good_frames'),
-                                    ('raw_data_1/duration', 'raw_data_1/duration'),
-                                    ('raw_data_1/start_time', 'raw_data_1/start_time'),
-                                    ('raw_data_1/end_time', 'raw_data_1/end_time'),
-                                    ('raw_data_1/run_cycle', 'raw_data_1/run_cycle'),
-                                    ('raw_data_1/title', 'raw_data_1/title'),
-                                    ('raw_data_1/detector_1_events',
-                                     'raw_data_1/detector_1_events'),
-                                    ('raw_data_1/detector_1_events/event_id',
-                                     'raw_data_1/detector_1_events/event_id'),
-                                    ('raw_data_1/detector_1_events/total_counts',
-                                     'raw_data_1/detector_1_events/total_counts'),
-                                    ('raw_data_1/detector_1_events/event_index',
-                                     'raw_data_1/detector_1_events/event_index'),
-                                    ('raw_data_1/detector_1_events/event_time_zero',
-                                     'raw_data_1/detector_1_events/event_time_zero'),
-                                    ('raw_data_1/detector_1_events/event_time_offset',
-                                     'raw_data_1/detector_1_events/event_time_offset'),
-                                    ('raw_data_1/monitor_1/data', 'raw_data_1/instrument/monitor1/data'),
-                                    ('raw_data_1/monitor_1/time_of_flight',
-                                     'raw_data_1/instrument/monitor1/time_of_flight'),
-                                    ('raw_data_1/monitor_2/data', 'raw_data_1/instrument/monitor2/data'),
-                                    ('raw_data_1/monitor_2/time_of_flight',
-                                     'raw_data_1/instrument/monitor2/time_of_flight'),
-                                    ('raw_data_1/monitor_3/data', 'raw_data_1/instrument/monitor3/data'),
-                                    ('raw_data_1/monitor_3/time_of_flight',
-                                     'raw_data_1/instrument/monitor3/time_of_flight'),
-                                    ('raw_data_1/monitor_4/data', 'raw_data_1/instrument/monitor4/data'),
-                                    ('raw_data_1/monitor_4/time_of_flight',
-                                     'raw_data_1/instrument/monitor4/time_of_flight'),
-                                    ]))
-    del builder
+        # Copy data from the existing NeXus file to flesh out the example file
+        builder.add_user('Sans2d Team', 'ISIS, STFC')
+        builder.copy_items(OrderedDict([('raw_data_1/instrument/moderator', 'raw_data_1/instrument/moderator'),
+                                        ('raw_data_1/instrument/moderator/distance',
+                                         'raw_data_1/instrument/moderator/distance'),
+                                        ('raw_data_1/instrument/source/probe', 'raw_data_1/instrument/source/probe'),
+                                        ('raw_data_1/instrument/source/type', 'raw_data_1/instrument/source/type'),
+                                        ('raw_data_1/sample/name', 'raw_data_1/sample/name'),
+                                        ('raw_data_1/sample/type', 'raw_data_1/sample/type'),
+                                        ('raw_data_1/good_frames', 'raw_data_1/good_frames'),
+                                        ('raw_data_1/duration', 'raw_data_1/duration'),
+                                        ('raw_data_1/start_time', 'raw_data_1/start_time'),
+                                        ('raw_data_1/end_time', 'raw_data_1/end_time'),
+                                        ('raw_data_1/run_cycle', 'raw_data_1/run_cycle'),
+                                        ('raw_data_1/title', 'raw_data_1/title'),
+                                        ('raw_data_1/detector_1_events',
+                                         'raw_data_1/detector_1_events'),
+                                        ('raw_data_1/detector_1_events/event_id',
+                                         'raw_data_1/detector_1_events/event_id'),
+                                        ('raw_data_1/detector_1_events/total_counts',
+                                         'raw_data_1/detector_1_events/total_counts'),
+                                        ('raw_data_1/detector_1_events/event_index',
+                                         'raw_data_1/detector_1_events/event_index'),
+                                        ('raw_data_1/detector_1_events/event_time_zero',
+                                         'raw_data_1/detector_1_events/event_time_zero'),
+                                        ('raw_data_1/detector_1_events/event_time_offset',
+                                         'raw_data_1/detector_1_events/event_time_offset'),
+                                        ('raw_data_1/monitor_1/data', 'raw_data_1/instrument/monitor1/data'),
+                                        ('raw_data_1/monitor_1/time_of_flight',
+                                         'raw_data_1/instrument/monitor1/time_of_flight'),
+                                        ('raw_data_1/monitor_2/data', 'raw_data_1/instrument/monitor2/data'),
+                                        ('raw_data_1/monitor_2/time_of_flight',
+                                         'raw_data_1/instrument/monitor2/time_of_flight'),
+                                        ('raw_data_1/monitor_3/data', 'raw_data_1/instrument/monitor3/data'),
+                                        ('raw_data_1/monitor_3/time_of_flight',
+                                         'raw_data_1/instrument/monitor3/time_of_flight'),
+                                        ('raw_data_1/monitor_4/data', 'raw_data_1/instrument/monitor4/data'),
+                                        ('raw_data_1/monitor_4/time_of_flight',
+                                         'raw_data_1/instrument/monitor4/time_of_flight'),
+                                        ]))
 
     plotter = DetectorPlotter(output_filename)
     plotter.plot_pixel_positions()

--- a/example_instruments/sans2d/nxlogexample.py
+++ b/example_instruments/sans2d/nxlogexample.py
@@ -12,6 +12,8 @@ def create_nexus_file(output_filename):
     builder.add_instrument_geometry_from_idf()
     __add_nxlog(builder)
     __copy_data_from_existing_file(builder)
+    nx_log_feature_id = "B051F43BC680C13B"
+    builder.add_features([nx_log_feature_id])
 
 
 def __copy_data_from_existing_file(builder):

--- a/example_instruments/sans2d/nxlogexample.py
+++ b/example_instruments/sans2d/nxlogexample.py
@@ -12,8 +12,6 @@ def create_nexus_file(output_filename):
     builder.add_instrument_geometry_from_idf()
     __add_nxlog(builder)
     __copy_data_from_existing_file(builder)
-    nx_log_feature_id = "B051F43BC680C13B"
-    builder.add_features([nx_log_feature_id])
 
 
 def __copy_data_from_existing_file(builder):

--- a/example_instruments/smallfake/SMALLFAKE_example.py
+++ b/example_instruments/smallfake/SMALLFAKE_example.py
@@ -4,10 +4,9 @@ from detectorplotter import DetectorPlotter
 if __name__ == '__main__':
     output_filename = 'SMALLFAKE_example_geometry.hdf5'
     # compress_type=32001 for BLOSC, or don't specify compress_type and opts to get non-compressed datasets
-    builder = NexusBuilder(output_filename, idf_file='SMALLFAKE_Definition.xml', compress_type='gzip', compress_opts=1)
-
-    builder.add_instrument_geometry_from_idf()
-    del builder
+    with NexusBuilder(output_filename, idf_file='SMALLFAKE_Definition.xml', compress_type='gzip',
+                      compress_opts=1) as builder:
+        builder.add_instrument_geometry_from_idf()
 
     plotter = DetectorPlotter(output_filename)
     plotter.plot_pixel_positions()

--- a/example_instruments/wish/WISH_example.py
+++ b/example_instruments/wish/WISH_example.py
@@ -4,10 +4,9 @@ from detectorplotter import DetectorPlotter
 if __name__ == '__main__':
     output_filename = 'WISH_example_gzip_compress.hdf5'
 
-    builder = NexusBuilder(output_filename, idf_file='WISH_Definition_10Panels.xml',
-                           compress_type='gzip', compress_opts=1)
-    builder.add_instrument_geometry_from_idf()
-    del builder  # file is closed in the builder destructor
+    with NexusBuilder(output_filename, idf_file='WISH_Definition_10Panels.xml',
+                      compress_type='gzip', compress_opts=1) as builder:
+        builder.add_instrument_geometry_from_idf()
 
     plotter = DetectorPlotter(output_filename)
     plotter.plot_pixel_positions()

--- a/nexusbuilder.py
+++ b/nexusbuilder.py
@@ -640,6 +640,7 @@ class NexusBuilder:
             self.add_dataset(self.instrument, 'name', name, {'short_name': name[:3]})
         else:
             self.add_dataset(self.instrument, 'name', name, {'short_name': name})
+        return self.instrument
 
     def add_transformation(self, group, transformation_type, values, units, vector, offset=None, name='transformation',
                            depends_on='.'):
@@ -748,3 +749,16 @@ class NexusBuilder:
         created_group = parent_group.create_group(group_name)
         created_group.attrs.create('NX_class', np.array(nx_class_name).astype('|S' + str(len(nx_class_name))))
         return created_group
+
+    def add_features(self, feature_ids):
+        """
+        Add a dataset details which "features" the file contains (see https://github.com/nexusformat/features)
+
+        :param feature_ids: list of 64 bit integers or hex strings
+        :return:
+        """
+        feature_ids_int64 = [int(feature_id, 16) if isinstance(feature_id, str) else feature_id for feature_id in
+                             feature_ids]
+
+        features_dataset = self.add_dataset(self.root, "features", feature_ids_int64)
+        return features_dataset

--- a/nexusbuilder.py
+++ b/nexusbuilder.py
@@ -57,6 +57,9 @@ class NexusBuilder:
         self.instrument = None
         self.features = set()
 
+    def __enter__(self):
+        return self
+
     def get_root(self):
         return self.root
 
@@ -406,14 +409,12 @@ class NexusBuilder:
         pixel_shape = self.add_shape(group, 'pixel_shape', vertices, faces)
         return pixel_shape
 
-    def __del__(self):
+    def __exit__(self, exc_type, exc_value, traceback):
         self.__add_features()
-        # Wrap in try to ignore exception which h5py likes to throw with Python 3.5
-        try:
+        if self.source_file is not None:
             self.source_file.close()
+        if self.target_file is not None:
             self.target_file.close()
-        except Exception:
-            pass
 
     def __add_nx_entry(self, nx_entry_name):
         entry_group = self.target_file.create_group(nx_entry_name)
@@ -491,6 +492,7 @@ class NexusBuilder:
             current_index += face[0]
             for vertex_index in face[1:]:
                 winding_order.append(vertex_index)
+        faces.append(current_index)
         return winding_order, faces
 
     def add_structured_detectors_from_idf(self):

--- a/nexusbuilder.py
+++ b/nexusbuilder.py
@@ -105,6 +105,9 @@ class NexusBuilder:
         if isinstance(group, str):
             group = self.root[group]
 
+        if name in group:
+            raise Exception(name + " dataset already exists, delete it before trying to create a new one")
+
         if isinstance(data, str):
             dataset = group.create_dataset(name, data=np.array(data).astype('|S' + str(len(data))))
         elif nexusutils.is_scalar(data):


### PR DESCRIPTION
A `features` dataset is automatically written to the output NeXus file based on what NX classes were created by the builder. Feature IDs can also be explicitly added to the feature set via a builder method.
 
**Example**
This makes it easier to create example files for NeXus features, for example:
```python
from nexusbuilder import NexusBuilder

with NexusBuilder("example_nx_geometry.nxs", compress_type="gzip", compress_opts=1) as builder:
  instrument_group = builder.add_instrument("TEAPOT")
  builder.add_shape_from_file("teapot.off", instrument_group, "shape")
```
A `features` dataset with the ID for the `NXoff_geometry` feature is automatically created in the output file.